### PR TITLE
Resolve issue #9 and convert to Qt5

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ Source and .pro file of the Qt Project are available. A standalone .exe is inclu
 All notable changes to this project will be documented below this line.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+
+## [1.3.2] - 2019-11-20
+
+### Info
+
+- Load settings at startup
+- Save settings at close event : port, baud, data, parity, stop, spinPoints, spinYStep, spinAxesMin, spinAxesMax
+
+### Bugfix
+
+- Solve issue #10 : Save and load settings
+
 ## [1.3.1] - 2019-11-20
 
 ### Info

--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ Source and .pro file of the Qt Project are available. A standalone .exe is inclu
 All notable changes to this project will be documented below this line.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.3.1] - 2019-11-20
+
+### Info
+
+- Built with QT 5.7.
+- Change #includes (Qwidget is a separate module)
+- Remove QApplication::UnicodeUTF8 in QApplication::translate method (read [Qt forum](https://forum.qt.io/topic/28054/unicodeutf8-not-member-qapplication-generated-with-qt5-designer/2))
+- add QDir::homePath() + in file name string in mainwindow.cpp in order to be able to save csv and png in home directory
+- add coordonateX(0) and spinPoints->value() in PNG name in order to be able to save multiple PNG from the same dataset with different zoom or drag
+- remove PNG export disable in order to allow export PNG after stop or pause
+
+### Bugfix
+
+- Solve issue #9 : Now export work on linux (maybe on mac too)
+
 ## [1.3.0] - 2018-08-01
 
 ### Info

--- a/SerialPortPlotter.pro
+++ b/SerialPortPlotter.pro
@@ -8,9 +8,11 @@ QT       += core gui
 QT       += serialport
 CONFIG += c++11
 
-greaterThan(QT_MAJOR_VERSION, 4): QT += widgets printsupport
+#greaterThan(QT_MAJOR_VERSION, 5): QT += widgets printsupport
 
-TARGET = serial_port_plotter
+QT += widgets printsupport
+
+TARGET = serialportplotter
 TEMPLATE = app
 
 SOURCES += main.cpp\
@@ -28,7 +30,7 @@ FORMS    += mainwindow.ui \
 
 RESOURCES += \
     res/serial_port_plotter.qrc \
-    res/qdark_stylesheet/qdarkstyle/style.qrc
+    #res/qdark_stylesheet/qdarkstyle/style.qrc      # don't exist
 
 # The following line compiles on Release but not on Debug, so this workaroung is used:
 RC_FILE = res/serial_port_plotter.rc
@@ -38,3 +40,26 @@ RC_FILE = res/serial_port_plotter.rc
 #win32:QMAKE_EXTRA_TARGETS += mkver_rc
 #win32:PRE_TARGETDEPS += serial_port_plotter_res.o
 #win32:LIBS += serial_port_plotter_res.o
+
+unix:configfiles.extra = chmod +x scripts/*; make clean;
+binfile.files += serial_port_plotter
+binfile.path = /usr/bin/
+#configfiles.files += data/config/*
+configfiles.path = /usr/share/
+docfiles.files += data/doc/*
+docfiles.path = /usr/share/doc/
+manfiles.files += data/man/*
+manfiles.path = /usr/share/man/man1/
+shortcutfiles.files += data/serialportplotter.desktop
+shortcutfiles.path = /usr/share/applications/
+INSTALLS += configfiles
+INSTALLS += docfiles
+INSTALLS += manfiles
+INSTALLS += shortcutfiles
+INSTALLS += binfile
+
+
+
+
+
+

--- a/helpwindow.hpp
+++ b/helpwindow.hpp
@@ -27,7 +27,7 @@
 #ifndef HELPWINDOW_HPP
 #define HELPWINDOW_HPP
 
-#include <QDialog>
+#include <QtWidgets/QDialog>
 
 namespace Ui {
     class HelpWindow;

--- a/main.cpp
+++ b/main.cpp
@@ -31,6 +31,10 @@ int main(int argc, char *argv[])
 {
     QApplication a(argc, argv);
 
+    a.setOrganizationName("SerialPortPlotter");         // give the folder name to store settings in local home
+    a.setApplicationName("SerialPortPlotter");          // give file config name (.conf)
+
+
     /* Apply style sheet */
     QFile file(":/serial_port_plotter/styles/style.qss");
     if(file.open(QIODevice::ReadOnly | QIODevice::Text))

--- a/main.cpp
+++ b/main.cpp
@@ -25,7 +25,7 @@
 ****************************************************************************/
 
 #include "mainwindow.hpp"
-#include <QApplication>
+#include <QtWidgets/QApplication>
 
 int main(int argc, char *argv[])
 {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -27,6 +27,7 @@
 #include "mainwindow.hpp"
 #include "ui_mainwindow.h"
 #include <x86intrin.h>
+#include <cstdio>
 
 /**
  * @brief Constructor
@@ -124,7 +125,7 @@ void MainWindow::createUI()
       {
         enable_com_controls (false);
         ui->statusBar->showMessage ("No ports detected.");
-        ui->savePNGButton->setEnabled (false);
+        ui->savePNGButton->setEnabled(false);
         return;
       }
 
@@ -550,7 +551,9 @@ void MainWindow::on_spinYStep_valueChanged(int arg1)
  */
 void MainWindow::on_savePNGButton_clicked()
 {
-    ui->plot->savePng (QString::number(dataPointNumber) + ".png", 1920, 1080, 2, 50);
+    ui->plot->savePng (QDir::homePath() + '/' + QString::number(dataPointNumber) + '_' + QString::number(ui->plot->xAxis->coordToPixel(0)) + '_' + QString::number(ui->spinPoints->value()) + ".png", 1920, 1080, 2, 50);
+    //ui->plot->savePng (QDir::homePath() + '/' + QString::number(dataPointNumber) + ".png", 1920, 1080, 2, 50);    // add home path before picture's name
+    //ui->plot->savePng (QString::number(dataPointNumber) + ".png", 1920, 1080, 2, 50);
 }
 /** ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
@@ -786,7 +789,7 @@ void MainWindow::on_actionDisconnect_triggered()
       ui->actionRecord_stream->setEnabled(true);
       receivedData.clear();                                                             // Clear received string
 
-      ui->savePNGButton->setEnabled (false);
+      //ui->savePNGButton->setEnabled (false);                                          // Disable export png, commented to be able to export when the plotting is stopped, permit zoom before export for example.
       enable_com_controls (true);
     }
 }
@@ -814,7 +817,8 @@ void MainWindow::on_actionClear_triggered()
  */
 void MainWindow::openCsvFile(void)
 {
-  m_csvFile = new QFile(QDateTime::currentDateTime().toString("yyyy-MM-d-HH-mm-ss-")+"data-out.csv");
+    m_csvFile = new QFile(QDir::homePath() + '/' + QDateTime::currentDateTime().toString("yyyy-MM-d-HH-mm-ss-")+"data-out.csv");    // add home path before picture's name
+  //m_csvFile = new QFile(QDateTime::currentDateTime().toString("yyyy-MM-d-HH-mm-ss-")+"data-out.csv");
   if(!m_csvFile)
       return;
   if (!m_csvFile->open(QIODevice::ReadWrite | QIODevice::Text))

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -817,8 +817,16 @@ void MainWindow::on_actionDisconnect_triggered()
  */
 void MainWindow::on_actionClear_triggered()
 {
-    ui->plot->clearPlottables();
-    ui->listWidget_Channels->clear();
+
+    // from https://www.qcustomplot.com/index.php/support/forum/1304
+    // delete dataset but not the graph
+    for( int g=0; g<ui->plot->graphCount(); g++ )
+    {
+        ui->plot->graph(g)->data().data()->clear();
+    }
+    ui->plot->replot();
+//    ui->plot->clearPlottables();
+//    ui->listWidget_Channels->clear();
     channels = 0;
     dataPointNumber = 0;
     emit setupPlot();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -153,7 +153,7 @@ void MainWindow::createUI()
     ui->comboBaud->addItem ("921600");
 
     /* Select 115200 bits by default */
-    ui->comboBaud->setCurrentIndex (7);
+    //ui->comboBaud->setCurrentIndex (7);       // done by loadSettings now
 
     /* Populate data bits combo box */
     ui->comboData->addItem ("8 bits");
@@ -170,7 +170,19 @@ void MainWindow::createUI()
 
     /* Initialize the listwidget */
     ui->listWidget_Channels->clear();
-}
+
+    // try to load settings, or populate with default value
+    loadSettings();
+    ui->comboPort->setCurrentIndex(m_prefs.port);
+    ui->comboBaud->setCurrentIndex(m_prefs.baud);
+    ui->comboData->setCurrentIndex(m_prefs.data);
+    ui->comboParity->setCurrentIndex(m_prefs.parity);
+    ui->comboStop->setCurrentIndex(m_prefs.stop);
+    ui->spinPoints->setValue(m_prefs.spinPoints);
+    ui->spinYStep->setValue(m_prefs.spinYStep);
+    ui->spinAxesMin->setValue(m_prefs.spinAxesMin);
+    ui->spinAxesMax->setValue(m_prefs.spinAxesMax);
+    }
 /** ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 /**
@@ -930,3 +942,56 @@ void MainWindow::on_pushButton_clicked()
         ui->comboPort->addItem (port.portName());
     }
 }
+
+/** ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+/**
+ * @brief Load settings from config file and populate preferences
+ *
+ */
+void MainWindow::loadSettings()
+{
+  QSettings settings;
+  m_prefs.port = settings.value("port", 0).toInt();
+  m_prefs.baud = settings.value("baud", 7).toInt();
+  m_prefs.data = settings.value("data", 0).toInt();
+  m_prefs.parity = settings.value("parity", 0).toInt();
+  m_prefs.stop = settings.value("stop", 0).toInt();
+  m_prefs.spinPoints = settings.value("spinPoints", 1000).toInt();
+  m_prefs.spinYStep = settings.value("spinYStep", 10).toInt();
+  m_prefs.spinAxesMin = settings.value("spinAxesMin", -100).toInt();
+  m_prefs.spinAxesMax = settings.value("spinAxesMax", 100).toInt();
+}
+
+/** ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+/**
+ * @brief Load settings from config file and populate preferences
+ *
+ */
+void MainWindow::saveSettings()
+{
+    QSettings settings;
+    settings.setValue("port", ui->comboPort->currentIndex());
+    settings.setValue("baud", ui->comboBaud->currentIndex());
+    settings.setValue("data", ui->comboData->currentIndex());
+    settings.setValue("parity", ui->comboParity->currentIndex());
+    settings.setValue("stop", ui->comboStop->currentIndex());
+    settings.setValue("spinPoints", ui->spinPoints->value());
+    settings.setValue("spinYStep", ui->spinYStep->value());
+    settings.setValue("spinAxesMin",  ui->spinAxesMin->value());
+    settings.setValue("spinAxesMax",  ui->spinAxesMax->value());
+}
+/** ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+/**
+ * @brief t the close event, save settings
+ *
+ */
+void MainWindow::closeEvent(QCloseEvent *event)
+{
+    saveSettings();
+    event->accept();
+}
+
+

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -27,7 +27,6 @@
 #include "mainwindow.hpp"
 #include "ui_mainwindow.h"
 #include <x86intrin.h>
-#include <cstdio>
 
 /**
  * @brief Constructor
@@ -125,7 +124,6 @@ void MainWindow::createUI()
       {
         enable_com_controls (false);
         ui->statusBar->showMessage ("No ports detected.");
-        ui->savePNGButton->setEnabled(false);
         return;
       }
 
@@ -182,6 +180,9 @@ void MainWindow::createUI()
     ui->spinYStep->setValue(m_prefs.spinYStep);
     ui->spinAxesMin->setValue(m_prefs.spinAxesMin);
     ui->spinAxesMax->setValue(m_prefs.spinAxesMax);
+
+    // disable PNG export before starting record
+    ui->actionRecord_PNG->setEnabled(false);
     }
 /** ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
@@ -559,9 +560,9 @@ void MainWindow::on_spinYStep_valueChanged(int arg1)
 /** ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 /**
- * @brief Save a PNG image of the plot to current EXE directory
+ * @brief Save a PNG image of the plot to current HOME directory
  */
-void MainWindow::on_savePNGButton_clicked()
+void MainWindow::on_actionRecord_PNG_triggered()
 {
     ui->plot->savePng (QDir::homePath() + '/' + QString::number(dataPointNumber) + '_' + QString::number(ui->plot->xAxis->coordToPixel(0)) + '_' + QString::number(ui->spinPoints->value()) + ".png", 1920, 1080, 2, 50);
     //ui->plot->savePng (QDir::homePath() + '/' + QString::number(dataPointNumber) + ".png", 1920, 1080, 2, 50);    // add home path before picture's name
@@ -742,6 +743,9 @@ void MainWindow::on_actionConnect_triggered()
 
       /* Open serial port and connect its signals */
       openPort (portInfo, baudRate, dataBits, parity, stopBits);
+
+      /* Enable PNG export */
+      ui->actionRecord_PNG->setEnabled(true);
   }
 }
 /** ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
@@ -801,7 +805,6 @@ void MainWindow::on_actionDisconnect_triggered()
       ui->actionRecord_stream->setEnabled(true);
       receivedData.clear();                                                             // Clear received string
 
-      //ui->savePNGButton->setEnabled (false);                                          // Disable export png, commented to be able to export when the plotting is stopped, permit zoom before export for example.
       enable_com_controls (true);
     }
 }
@@ -820,6 +823,9 @@ void MainWindow::on_actionClear_triggered()
     dataPointNumber = 0;
     emit setupPlot();
     ui->plot->replot();
+
+    /* Disable PNG export */
+    ui->actionRecord_PNG->setEnabled(false);
 }
 /** ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 

--- a/mainwindow.hpp
+++ b/mainwindow.hpp
@@ -27,7 +27,7 @@
 #ifndef MAINWINDOW_HPP
 #define MAINWINDOW_HPP
 
-#include <QMainWindow>
+#include <QtWidgets/QMainWindow>
 #include <QtSerialPort/QtSerialPort>
 #include <QSerialPortInfo>
 #include "helpwindow.hpp"
@@ -113,6 +113,7 @@ private:
     bool connected;                                                                       // Status connection variable
     bool plotting;                                                                        // Status plotting variable
     int dataPointNumber;                                                                  // Keep track of data points
+    char buffer[10];                                                                      // buffer to convert number in string for png export
     /* Channels of data (number of graphs) */
     int channels;
 

--- a/mainwindow.hpp
+++ b/mainwindow.hpp
@@ -54,6 +54,7 @@ class MainWindow : public QMainWindow
 public:
     explicit MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
+    void closeEvent(QCloseEvent *event);                                                // close event to save settings
 
 private slots:
     void on_comboPort_currentIndexChanged(const QString &arg1);                           // Slot displays message on status bar
@@ -132,6 +133,21 @@ private:
     void openCsvFile(void);
     void closeCsvFile(void);
 
+    /* Preferences */
+    struct SPreferences
+    {
+        int port;                                                                       // last port used
+        int baud;                                                                       // last baudrate item used
+        int data;                                                                       // last data length used
+        int parity;                                                                     // last parity used
+        int stop;                                                                       // last stop bit number
+        int spinPoints;
+        int spinYStep;                                                                  // last value used
+        int spinAxesMin;                                                                // last value used
+        int spinAxesMax;                                                                // last value used
+    };
+    SPreferences m_prefs;                                                               // preferences stucture
+
     QTimer updateTimer;                                                                   // Timer used for replotting the plot
     QTime timeOfFirstData;                                                                // Record the time of the first data point
     double timeBetweenSamples;                                                            // Store time between samples
@@ -146,6 +162,9 @@ private:
     void setupPlot();                                                                     // Setup the QCustomPlot
                                                                                           // Open the inside serial port with these parameters
     void openPort(QSerialPortInfo portInfo, int baudRate, QSerialPort::DataBits dataBits, QSerialPort::Parity parity, QSerialPort::StopBits stopBits);
+
+    void loadSettings();                                                                // load settings to populate preferences fro; config file
+    void saveSettings();                                                                // sqve preferences in config file
 };
 
 

--- a/mainwindow.hpp
+++ b/mainwindow.hpp
@@ -69,7 +69,7 @@ private slots:
     void readData();                                                                      // Slot for inside serial port
     //void on_comboAxes_currentIndexChanged(int index);                                     // Display number of axes and colors in status bar
     void on_spinYStep_valueChanged(int arg1);                                             // Spin box for changing Y axis tick step
-    void on_savePNGButton_clicked();                                                      // Button for saving JPG
+    //void on_savePNGButton_clicked();                                                      // Button for saving JPG
     void onMouseMoveInPlot (QMouseEvent *event);                                          // Displays coordinates of mouse pointer when clicked in plot in status bar
     void on_spinPoints_valueChanged (int arg1);                                           // Spin box controls how many data points are collected and displayed
     void on_mouse_wheel_in_plot (QWheelEvent *event);                                     // Makes wheel mouse works while plotting
@@ -84,6 +84,7 @@ private slots:
     void on_actionPause_Plot_triggered();
     void on_actionClear_triggered();
     void on_actionRecord_stream_triggered();
+    void on_actionRecord_PNG_triggered();
 
     void on_pushButton_TextEditHide_clicked();
 
@@ -96,6 +97,7 @@ private slots:
     void on_listWidget_Channels_itemDoubleClicked(QListWidgetItem *item);
 
     void on_pushButton_clicked();
+
 
 signals:
     void portOpenFail();                                                                  // Emitted when cannot open port
@@ -114,6 +116,7 @@ private:
     bool connected;                                                                       // Status connection variable
     bool plotting;                                                                        // Status plotting variable
     int dataPointNumber;                                                                  // Keep track of data points
+
     char buffer[10];                                                                      // buffer to convert number in string for png export
     /* Channels of data (number of graphs) */
     int channels;

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -706,7 +706,7 @@
   </widget>
   <action name="actionConnect">
    <property name="icon">
-    <iconset resource="../res/serial_port_plotter.qrc">
+    <iconset resource="res/serial_port_plotter.qrc">
      <normaloff>:/serial_port_plotter/play_nor.png</normaloff>
      <normalon>:/serial_port_plotter/play_nor.png</normalon>
      <disabledoff>:/serial_port_plotter/play_dis.png</disabledoff>
@@ -728,7 +728,7 @@
     <bool>false</bool>
    </property>
    <property name="icon">
-    <iconset resource="../res/serial_port_plotter.qrc">
+    <iconset resource="res/serial_port_plotter.qrc">
      <normaloff>:/serial_port_plotter/pause_nor.png</normaloff>
      <normalon>:/serial_port_plotter/pause_nor.png</normalon>
      <disabledoff>:/serial_port_plotter/pause_dis.png</disabledoff>
@@ -750,7 +750,7 @@
     <bool>false</bool>
    </property>
    <property name="icon">
-    <iconset resource="../res/serial_port_plotter.qrc">
+    <iconset resource="res/serial_port_plotter.qrc">
      <normaloff>:/serial_port_plotter/stop_nor.png</normaloff>
      <normalon>:/serial_port_plotter/stop_nor.png</normalon>
      <disabledoff>:/serial_port_plotter/stop_dis.png</disabledoff>
@@ -772,7 +772,7 @@
     <bool>true</bool>
    </property>
    <property name="icon">
-    <iconset resource="../res/serial_port_plotter.qrc">
+    <iconset resource="res/serial_port_plotter.qrc">
      <normaloff>:/serial_port_plotter/clear_nor.png</normaloff>
      <normalon>:/serial_port_plotter/clear_nor.png</normalon>
      <disabledoff>:/serial_port_plotter/clear_dis.png</disabledoff>
@@ -791,7 +791,7 @@
   </action>
   <action name="actionHow_to_use">
    <property name="icon">
-    <iconset resource="../res/serial_port_plotter.qrc">
+    <iconset resource="res/serial_port_plotter.qrc">
      <normaloff>:/serial_port_plotter/help_nor.png</normaloff>
      <normalon>:/serial_port_plotter/help_nor.png</normalon>
      <disabledoff>:/serial_port_plotter/help_dis.png</disabledoff>
@@ -816,7 +816,7 @@
     <bool>true</bool>
    </property>
    <property name="icon">
-    <iconset resource="../res/serial_port_plotter.qrc">
+    <iconset resource="res/serial_port_plotter.qrc">
      <normaloff>:/icons/line_icon_set/document.png</normaloff>
      <normalon>:/icons/line_icon_set_text/document.png</normalon>
      <disabledoff>:/icons/line_icon_set/document.png</disabledoff>:/icons/line_icon_set/document.png</iconset>
@@ -845,7 +845,7 @@
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="../res/serial_port_plotter.qrc"/>
+  <include location="res/serial_port_plotter.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -528,13 +528,6 @@
              </property>
             </widget>
            </item>
-           <item>
-            <widget class="QPushButton" name="savePNGButton">
-             <property name="text">
-              <string>Save PNG</string>
-             </property>
-            </widget>
-           </item>
           </layout>
          </item>
         </layout>
@@ -555,12 +548,6 @@
       </item>
       <item>
        <widget class="QGroupBox" name="gridGroupBox">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>80</height>
-         </size>
-        </property>
         <property name="title">
          <string>TEXT CONTROLS</string>
         </property>
@@ -703,6 +690,7 @@
    <addaction name="actionHow_to_use"/>
    <addaction name="separator"/>
    <addaction name="actionRecord_stream"/>
+   <addaction name="actionRecord_PNG"/>
   </widget>
   <action name="actionConnect">
    <property name="icon">
@@ -832,6 +820,18 @@
    </property>
    <property name="visible">
     <bool>true</bool>
+   </property>
+  </action>
+  <action name="actionRecord_PNG">
+   <property name="icon">
+    <iconset resource="res/serial_port_plotter.qrc">
+     <normaloff>:/serial_port_plotter/ExPNG_nor.png</normaloff>:/serial_port_plotter/ExPNG_nor.png</iconset>
+   </property>
+   <property name="text">
+    <string>Record_PNG</string>
+   </property>
+   <property name="toolTip">
+    <string>Record the currently plot view in PNG image.</string>
    </property>
   </action>
  </widget>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -706,7 +706,7 @@
   </widget>
   <action name="actionConnect">
    <property name="icon">
-    <iconset resource="res/serial_port_plotter.qrc">
+    <iconset resource="../res/serial_port_plotter.qrc">
      <normaloff>:/serial_port_plotter/play_nor.png</normaloff>
      <normalon>:/serial_port_plotter/play_nor.png</normalon>
      <disabledoff>:/serial_port_plotter/play_dis.png</disabledoff>
@@ -728,7 +728,7 @@
     <bool>false</bool>
    </property>
    <property name="icon">
-    <iconset resource="res/serial_port_plotter.qrc">
+    <iconset resource="../res/serial_port_plotter.qrc">
      <normaloff>:/serial_port_plotter/pause_nor.png</normaloff>
      <normalon>:/serial_port_plotter/pause_nor.png</normalon>
      <disabledoff>:/serial_port_plotter/pause_dis.png</disabledoff>
@@ -750,7 +750,7 @@
     <bool>false</bool>
    </property>
    <property name="icon">
-    <iconset resource="res/serial_port_plotter.qrc">
+    <iconset resource="../res/serial_port_plotter.qrc">
      <normaloff>:/serial_port_plotter/stop_nor.png</normaloff>
      <normalon>:/serial_port_plotter/stop_nor.png</normalon>
      <disabledoff>:/serial_port_plotter/stop_dis.png</disabledoff>
@@ -772,7 +772,7 @@
     <bool>true</bool>
    </property>
    <property name="icon">
-    <iconset resource="res/serial_port_plotter.qrc">
+    <iconset resource="../res/serial_port_plotter.qrc">
      <normaloff>:/serial_port_plotter/clear_nor.png</normaloff>
      <normalon>:/serial_port_plotter/clear_nor.png</normalon>
      <disabledoff>:/serial_port_plotter/clear_dis.png</disabledoff>
@@ -791,7 +791,7 @@
   </action>
   <action name="actionHow_to_use">
    <property name="icon">
-    <iconset resource="res/serial_port_plotter.qrc">
+    <iconset resource="../res/serial_port_plotter.qrc">
      <normaloff>:/serial_port_plotter/help_nor.png</normaloff>
      <normalon>:/serial_port_plotter/help_nor.png</normalon>
      <disabledoff>:/serial_port_plotter/help_dis.png</disabledoff>
@@ -816,7 +816,7 @@
     <bool>true</bool>
    </property>
    <property name="icon">
-    <iconset resource="res/serial_port_plotter.qrc">
+    <iconset resource="../res/serial_port_plotter.qrc">
      <normaloff>:/icons/line_icon_set/document.png</normaloff>
      <normalon>:/icons/line_icon_set_text/document.png</normalon>
      <disabledoff>:/icons/line_icon_set/document.png</disabledoff>:/icons/line_icon_set/document.png</iconset>
@@ -845,7 +845,7 @@
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="res/serial_port_plotter.qrc"/>
+  <include location="../res/serial_port_plotter.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/res/serial_port_plotter.qrc
+++ b/res/serial_port_plotter.qrc
@@ -17,6 +17,9 @@
         <file alias="stop_act.png">icons/lynny-2x_white/Stop.png</file>
         <file alias="clear_act.png">icons/lynny-2x_white/No Entry.png</file>
         <file alias="help_act.png">icons/lynny-2x_white/Help.png</file>
+        <file alias="ExPNG_dis.png">icons/lynny-2x/File Type PNG.png</file>
+        <file alias="ExPNG_nor.png">icons/lynny-2x_text/File Type PNG.png</file>
+        <file alias="ExPNG_act.png">icons/lynny-2x_white/File Type PNG.png</file>
     </qresource>
     <qresource prefix="/">
         <file>icons/line_icon_set/document.png</file>


### PR DESCRIPTION
I've done some small things :

- Built with QT 5.7.
- Change #includes (Qwidget is a separate module)
- Remove QApplication::UnicodeUTF8 in QApplication::translate method (read Qt forum)
- add QDir::homePath() + in file name string in mainwindow.cpp in order to be able to save csv and png in home directory
- add coordonateX(0) and spinPoints->value() in PNG name in order to be able to save multiple PNG from the same dataset with different zoom or drag
- remove PNG export disable in order to allow export PNG after stop or pause

I hope you will find it usefull and working on windows

cheers
